### PR TITLE
Add support for per-book copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ for a complete example of use.
 
 [license]: https://httpd.apache.org/docs/2.2/license.html
 [creative-scala]: https://github.com/underscoreio/creative-scala
+
+## Configuration Guide
+
+The following settings are supported a book's _metadata.yaml_:
+
+ Key           | Value
+-------------- | -------------
+`title`        | String
+`author`       | String, multiple authors represented as: `Name and Name`
+`date`         | String, publication identifier such as: `Early Access May 2015`
+`filenameStem` | String, filename used for HTML, EPUB, PDF output. E.g., `essential-play`
+`copyright`    | String, copyright year or range: `2015` or `2011-2015`.
+`tocDepth`     | Integer, number of levels for table of contents. E.g., `3`
+`pages`        | Array, list of pages in rendering order
+`coverColor`   | String, colour of PDF cover. E.g., `F58B40`

--- a/index.coffee
+++ b/index.coffee
@@ -71,6 +71,9 @@ module.exports = (grunt, options = {}) ->
   unless Array.isArray(meta.pages)
     grunt.fail.fatal("'pages' in metadata must be an array of strings")
 
+  unless meta.copyright
+    grunt.fail.fatal("'copyright' in metadata must be a string such as '2015' or '2014-20155'")
+
   grunt.initConfig
     clean:
       main:

--- a/lib/templates/template.epub.html
+++ b/lib/templates/template.epub.html
@@ -33,7 +33,7 @@ $endif$
 <div style="page-break-before: always; padding-top: 3em">
   <p class="lead text-center">$title$$if(subtitle)$ $subtitle$$endif$</p>
 
-  <p class="text-center">Copyright 2014 $author$.</p>
+  <p class="text-center">Copyright $copyright$ $author$.</p>
 
   <p class="text-center">Published by <a href="http://underscore.io">Underscore Consulting LLP</a>, Brighton, UK.</p>
 

--- a/lib/templates/template.html
+++ b/lib/templates/template.html
@@ -75,7 +75,7 @@ $if(toc)$
 <div class="toc-contents">
 <p class="text-center">$title$$if(subtitle)$ $subtitle$$endif$</p>
 
-<p class="text-center">Copyright 2014 $author$.</p>
+<p class="text-center">Copyright $copyright$ $author$.</p>
 
 <p class="text-center">Published by <a href="http://underscore.io">Underscore Consulting LLP</a>, Brighton, UK.</p>
 
@@ -134,7 +134,7 @@ $endfor$
     </div>
 
     <p class="copyright text-center">
-      Copyright 2014 $author$.
+      Copyright $copyright$ $author$.
     </p>
   </div>
 </footer>

--- a/lib/templates/template.tex
+++ b/lib/templates/template.tex
@@ -289,7 +289,7 @@ $endif$
 
 \vspace{1cm}
 
-Copyright 2014 $author$.
+Copyright $copyright$ $author$.
 \end{center}
 \end{bottompar}
 
@@ -320,7 +320,7 @@ $endif$
 
 $date$
 
-Copyright 2014 $author$.
+Copyright $copyright$ $author$.
 
 Published by \href{http://underscore.io}{Underscore Consulting LLP}, Brighton, UK.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore-ebook-template",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Template for Underscore eBooks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds a requirement to include `copyright` in _metadata.yaml_.

E.g., `copyright: "2015"`

@davegurnell for your review - not urgent.
