### PR TITLE
Add \tightlist

### DIFF
--- a/lib/templates/template.tex
+++ b/lib/templates/template.tex
@@ -1,7 +1,6 @@
-\documentclass[$if(fontsize)$$fontsize$$else$12pt$endif$,$if(lang)$$lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+% Underscore modified version of pandoc --print-default-template latex
 
-\providecommand{\tightlist}{%
-  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\documentclass[$if(fontsize)$$fontsize$$else$12pt$endif$,$if(lang)$$lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 
 % Colors ----------------------------------------
 
@@ -162,6 +161,8 @@ $endif$
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 $if(numbersections)$
 \setcounter{secnumdepth}{5}
 $else$
@@ -170,6 +171,8 @@ $endif$
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
+
+
 $if(lang)$
 \ifxetex
   \usepackage{polyglossia}

--- a/lib/templates/template.tex
+++ b/lib/templates/template.tex
@@ -1,5 +1,8 @@
 \documentclass[$if(fontsize)$$fontsize$$else$12pt$endif$,$if(lang)$$lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 % Colors ----------------------------------------
 
 \usepackage[xcolor]{mdframed}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore-ebook-template",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Template for Underscore eBooks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
_Essential Slick_ `grunt pdf` fails with:

```
>> ! Undefined control sequence.
>> l.317 \tightlist
>>
>> pandoc: E
>> rror producing PDF from TeX source
>> Shell command exited with code 43
```

This appears to be due to Pandoc from version 1.14 now including a definition for `\tightlist` in the TeX template -- based on the research in https://github.com/rstudio/rmarkdown/issues/439

This PR copies the definition into our template, and bumps the version.  Using it I can get _Essential Slick_ to build OK.
