### PR TITLE
Allow users to override directories for Markdown, CSS, etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,20 @@
   fs = require('fs');
 
   module.exports = function(grunt, options) {
-    var createObject, distDir, joinLines, libDir, meta, minify, runCommand, srcDir, _ref, _ref1, _ref2, _ref3, _ref4, _ref5;
+    var coverSrcDir, createObject, cssSrcDir, distDir, joinLines, jsSrcDir, libDir, meta, metaSrcDir, minify, pageSrcDir, runCommand, srcDir, tplSrcDir, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref14, _ref15, _ref16, _ref17, _ref18, _ref19, _ref2, _ref20, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
     if (options == null) {
       options = {};
     }
     minify = (_ref = grunt.option('minify')) != null ? _ref : false;
-    libDir = (_ref1 = options.lib) != null ? _ref1 : "node_modules/underscore-ebook-template/lib";
-    srcDir = (_ref2 = options.src) != null ? _ref2 : "src";
-    distDir = (_ref3 = options.dist) != null ? _ref3 : "dist";
+    libDir = (_ref1 = (_ref2 = options.dir) != null ? _ref2.lib : void 0) != null ? _ref1 : "node_modules/underscore-ebook-template/lib";
+    srcDir = (_ref3 = (_ref4 = options.dir) != null ? _ref4.src : void 0) != null ? _ref3 : "src";
+    distDir = (_ref5 = (_ref6 = options.dir) != null ? _ref6.dist : void 0) != null ? _ref5 : "dist";
+    metaSrcDir = (_ref7 = (_ref8 = options.dir) != null ? _ref8.meta : void 0) != null ? _ref7 : "" + srcDir + "/meta";
+    pageSrcDir = (_ref9 = (_ref10 = options.dir) != null ? _ref10.page : void 0) != null ? _ref9 : "" + srcDir + "/pages";
+    cssSrcDir = (_ref11 = (_ref12 = options.dir) != null ? _ref12.css : void 0) != null ? _ref11 : "" + srcDir + "/css";
+    jsSrcDir = (_ref13 = (_ref14 = options.dir) != null ? _ref14.js : void 0) != null ? _ref13 : "" + srcDir + "/js";
+    tplSrcDir = (_ref15 = (_ref16 = options.dir) != null ? _ref16.template : void 0) != null ? _ref15 : "" + srcDir + "/templates";
+    coverSrcDir = (_ref17 = (_ref18 = options.dir) != null ? _ref18.cover : void 0) != null ? _ref17 : "" + srcDir + "/covers";
     grunt.loadNpmTasks("grunt-browserify");
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-contrib-connect");
@@ -31,11 +37,11 @@
       return lines.split(/[ \r\n]+/).join(" ");
     };
     createObject = function() {
-      var ans, key, pairs, value, _i, _len, _ref4;
+      var ans, key, pairs, value, _i, _len, _ref19;
       pairs = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
       ans = {};
       for (_i = 0, _len = pairs.length; _i < _len; _i++) {
-        _ref4 = pairs[_i], key = _ref4[0], value = _ref4[1];
+        _ref19 = pairs[_i], key = _ref19[0], value = _ref19[1];
         ans[key] = value;
       }
       return ans;
@@ -67,15 +73,15 @@
         }
       });
     };
-    meta = yaml.safeLoad(fs.readFileSync("./" + srcDir + "/meta/metadata.yaml", 'utf8'));
+    meta = yaml.safeLoad(fs.readFileSync("./" + metaSrcDir + "/metadata.yaml", 'utf8'));
     if (typeof meta.filenameStem !== "string") {
       grunt.fail.fatal("'filename' in metadata must be a string");
     }
     if (meta.exercises) {
-      if (typeof ((_ref4 = meta.exercises) != null ? _ref4.repo : void 0) !== "string") {
+      if (typeof ((_ref19 = meta.exercises) != null ? _ref19.repo : void 0) !== "string") {
         grunt.fail.fatal("'exercises.repo' in metadata must be a string");
       }
-      if (typeof ((_ref5 = meta.exercises) != null ? _ref5.name : void 0) !== "string") {
+      if (typeof ((_ref20 = meta.exercises) != null ? _ref20.name : void 0) !== "string") {
         grunt.fail.fatal("'exercises.name' in metadata must be a string");
       }
     } else if (meta.exercisesRepo) {
@@ -83,6 +89,9 @@
     }
     if (!Array.isArray(meta.pages)) {
       grunt.fail.fatal("'pages' in metadata must be an array of strings");
+    }
+    if (!meta.copyright) {
+      grunt.fail.fatal("'copyright' in metadata must be a string such as '2015' or '2014-2015'");
     }
     grunt.initConfig({
       clean: {
@@ -93,7 +102,7 @@
       less: {
         main: {
           options: {
-            paths: ["" + srcDir + "/css", "" + libDir + "/css", "node_modules"],
+            paths: [cssSrcDir, "" + libDir + "/css", "node_modules"],
             compress: minify,
             yuicompress: minify,
             modifyVars: {
@@ -137,23 +146,23 @@
           livereload: true
         },
         css: {
-          files: ["" + libDir + "/css/**/*", "" + srcDir + "/css/**/*"],
+          files: ["" + libDir + "/css/**/*", "" + cssSrcDir + "/**/*"],
           tasks: ["less", "cssUrlEmbed", "pandoc:html"]
         },
         js: {
-          files: ["" + libDir + "/js/**/*", "" + srcDir + "/js/**/*"],
+          files: ["" + libDir + "/js/**/*", "" + jsSrcDir + "/**/*"],
           tasks: ["browserify", "pandoc:html"]
         },
         templates: {
-          files: ["" + libDir + "/templates/**/*", "" + srcDir + "/templates/**/*"],
+          files: ["" + libDir + "/templates/**/*", "" + tplSrcDir + "/**/*"],
           tasks: ["pandoc:html"]
         },
         pages: {
-          files: ["" + srcDir + "/pages/**/*"],
+          files: ["" + pageSrcDir + "/**/*"],
           tasks: ["pandoc:html"]
         },
         metadata: {
-          files: ["" + srcDir + "/meta/**/*"],
+          files: ["" + metaSrcDir + "/**/*"],
           tasks: ["pandoc:html"]
         }
       },
@@ -168,7 +177,7 @@
     });
     grunt.renameTask("watch", "watchImpl");
     grunt.registerTask("pandoc", "Run pandoc", function(target, preview) {
-      var command, extras, filters, metadata, output, pages, template, variables, _ref6, _ref7, _ref8, _ref9;
+      var command, extras, filters, metadata, output, pages, template, variables, _ref21, _ref22, _ref23, _ref24;
       if (preview == null) {
         preview = false;
       }
@@ -180,39 +189,39 @@
           output = "--output=" + distDir + "/" + meta.filenameStem + ".pdf";
           template = "--template=" + libDir + "/templates/template.tex";
           variables = joinLines("--variable=lib-dir:" + libDir);
-          filters = joinLines("--filter=pandoc-crossref\n" + "--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee\n--filter=" + libDir + "/filters/pdf/vector-images.coffee");
-          extras = joinLines("--toc-depth=" + ((_ref6 = meta.tocDepth) != null ? _ref6 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.tex");
-          metadata = "" + srcDir + "/meta/pdf.yaml";
+          filters = joinLines("--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee\n--filter=" + libDir + "/filters/pdf/vector-images.coffee");
+          extras = joinLines("--toc-depth=" + ((_ref21 = meta.tocDepth) != null ? _ref21 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.tex");
+          metadata = "" + metaSrcDir + "/pdf.yaml";
           break;
         case "pdfpreview":
           output = "--output=" + distDir + "/" + meta.filenameStem + ".pdf";
           template = "--template=" + libDir + "/templates/template.tex";
           variables = joinLines("--variable=lib-dir:" + libDir);
-          filters = joinLines("--filter=pandoc-crossref\n" + "--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee\n--filter=" + libDir + "/filters/pdf/vector-images.coffee");
-          extras = joinLines("--toc-depth=" + ((_ref7 = meta.tocDepth) != null ? _ref7 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.tex");
-          metadata = "" + srcDir + "/meta/pdf.yaml";
+          filters = joinLines("--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee\n--filter=" + libDir + "/filters/pdf/vector-images.coffee");
+          extras = joinLines("--toc-depth=" + ((_ref22 = meta.tocDepth) != null ? _ref22 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.tex");
+          metadata = "" + metaSrcDir + "/pdf.yaml";
           break;
         case "html":
           output = "--output=" + distDir + "/" + meta.filenameStem + ".html";
           template = "--template=" + libDir + "/templates/template.html";
           variables = joinLines("--variable=lib-dir:" + libDir);
-          filters = joinLines("--filter=pandoc-crossref\n" + "--filter=" + libDir + "/filters/html/tables.coffee\n--filter=" + libDir + "/filters/html/solutions.coffee\n--filter=" + libDir + "/filters/html/vector-images.coffee");
-          extras = joinLines("--toc-depth=" + ((_ref8 = meta.tocDepth) != null ? _ref8 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.html");
-          metadata = "" + srcDir + "/meta/html.yaml";
+          filters = joinLines("--filter=" + libDir + "/filters/html/tables.coffee\n--filter=" + libDir + "/filters/html/solutions.coffee\n--filter=" + libDir + "/filters/html/vector-images.coffee");
+          extras = joinLines("--toc-depth=" + ((_ref23 = meta.tocDepth) != null ? _ref23 : 2) + "\n--include-before-body=" + libDir + "/templates/cover-notes.html");
+          metadata = "" + metaSrcDir + "/html.yaml";
           break;
         case "epub":
           output = "--output=" + distDir + "/" + meta.filenameStem + ".epub";
           template = "--template=" + libDir + "/templates/template.epub.html";
           variables = joinLines("--variable=lib-dir:" + libDir);
-          filters = joinLines("--filter=pandoc-crossref\n" + "--filter=" + libDir + "/filters/epub/solutions.coffee\n--filter=" + libDir + "/filters/epub/vector-images.coffee");
-          extras = joinLines("--toc-depth=" + ((_ref9 = meta.tocDepth) != null ? _ref9 : 2) + "\n--epub-stylesheet=" + distDir + "/temp/epub/main.css\n--epub-cover-image=" + srcDir + "/covers/epub-cover.png\n--include-before-body=" + libDir + "/templates/cover-notes.html");
-          metadata = "" + srcDir + "/meta/epub.yaml";
+          filters = joinLines("--filter=" + libDir + "/filters/epub/solutions.coffee\n--filter=" + libDir + "/filters/epub/vector-images.coffee");
+          extras = joinLines("--toc-depth=" + ((_ref24 = meta.tocDepth) != null ? _ref24 : 2) + "\n--epub-stylesheet=" + distDir + "/temp/epub/main.css\n--epub-cover-image=" + coverSrcDir + "/epub-cover.png\n--include-before-body=" + libDir + "/templates/cover-notes.html");
+          metadata = "" + metaSrcDir + "/epub.yaml";
           break;
         case "json":
           output = "--output=" + distDir + "/" + meta.filenameStem + ".json";
           template = "";
           variables = joinLines("--variable=lib-dir:" + libDir);
-          filters = joinLines("--filter=pandoc-crossref\n" + "--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee");
+          filters = joinLines("--filter=" + libDir + "/filters/pdf/callout.coffee\n--filter=" + libDir + "/filters/pdf/columns.coffee\n--filter=" + libDir + "/filters/pdf/solutions.coffee");
           extras = "";
           metadata = "";
           break;
@@ -223,23 +232,27 @@
         if (meta.previewPages) {
           output = output.replace(/([.][a-z]+)$/i, "-preview$1");
           variables = "" + variables + " --metadata=title:'Preview: " + meta.title + "'";
-          pages = meta.previewPages.join(" ");
+          pages = meta.previewPages.map(function(page) {
+            return "" + pageSrcDir + "/" + page;
+          }).join(" ");
         } else {
           return;
         }
       } else {
-        pages = meta.pages.join(" ");
+        pages = meta.pages.map(function(page) {
+          return "" + pageSrcDir + "/" + page;
+        }).join(" ");
       }
-      command = joinLines("pandoc\n--smart\n" + output + "\n" + template + "\n--from=markdown+grid_tables+multiline_tables+fenced_code_blocks+fenced_code_attributes+yaml_metadata_block+implicit_figures+header_attributes+definition_lists\n--latex-engine=xelatex\n" + variables + "\n" + filters + "\n--chapters\n--number-sections\n--table-of-contents\n--highlight-style tango\n--standalone\n--self-contained\n" + extras + "\n" + srcDir + "/meta/metadata.yaml\n" + metadata + "\n" + pages);
+      command = joinLines("pandoc\n--smart\n" + output + "\n" + template + "\n--from=markdown+grid_tables+multiline_tables+fenced_code_blocks+fenced_code_attributes+yaml_metadata_block+implicit_figures+header_attributes+definition_lists+link_attributes\n--latex-engine=xelatex\n" + variables + "\n" + filters + "\n--chapters\n--number-sections\n--table-of-contents\n--highlight-style tango\n--standalone\n--self-contained\n" + extras + "\n" + metaSrcDir + "/metadata.yaml\n" + metadata + "\n" + pages);
       return runCommand(command, this.async());
     });
     grunt.registerTask("exercises", "Download and build exercises", function(target) {
-      var command, name, repo, _ref6, _ref7;
-      if (!((_ref6 = meta.exercises) != null ? _ref6.repo : void 0)) {
+      var command, name, repo, _ref21, _ref22;
+      if (!((_ref21 = meta.exercises) != null ? _ref21.repo : void 0)) {
         return;
       }
       repo = meta.exercises.repo;
-      name = (_ref7 = meta.exercises.name) != null ? _ref7 : "" + meta.filenameStem + "-code";
+      name = (_ref22 = meta.exercises.name) != null ? _ref22 : "" + meta.filenameStem + "-code";
       command = joinLines("rm -rf " + name + " &&\ngit clone " + repo + " &&\nzip -r " + name + ".zip " + name);
       return runCommand(command, this.async(), {
         cwd: 'dist'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore-ebook-template",
-  "version": "0.0.19",
+  "version": "0.1.0",
   "description": "Template for Underscore eBooks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR allows users to override the directories for specific types of file.
This is useful, for example, for adding Tut to our pipeline:
- source files go in `src/pages` as usual;
- Tut compiles to `target/pages`, where editors are configured not to go;
- Grunt config specifies `target/pages` as the source for Pandoc compilation.

For example:

``` coffee
#global module:false

"use strict"

ebook = require 'underscore-ebook-template'

module.exports = (grunt) ->
  ebook(grunt, { dir: { page: "target/pages" } })
  return
```

**NOTE: Breaking change! This update requires users to specify relative filenames instead of absolute filenames in `metadata.yaml`. For example:

``` yaml

---
title: "Advanced Scala with Cats"
pages:
  - intro/foreword.md
  - intro/early-access.md
  - intro/conventions.md
  - intro/acknowledgements.md
```

instead of:

``` yaml

---
title: "Advanced Scala with Cats"
pages:
  - src/pages/intro/foreword.md
  - src/pages/intro/early-access.md
  - src/pages/intro/conventions.md
  - src/pages/intro/acknowledgements.md
```

There is a demo build in the (Underscore-internal) repo for Advanced Scala, in the `feature/file-layout` branch.
